### PR TITLE
Fix early golem material registration causing required items to be missing / air

### DIFF
--- a/src/main/java/com/github/voxelfriend/engineeredgolems/core/CommonProxy.java
+++ b/src/main/java/com/github/voxelfriend/engineeredgolems/core/CommonProxy.java
@@ -36,7 +36,6 @@ public class CommonProxy {
 	public void preInit(FMLPreInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(this);
         ModItems.init();
-        initGolems();
     }
 
 	public void init(FMLInitializationEvent event) {
@@ -47,7 +46,8 @@ public class CommonProxy {
                 new ResourceLocation("thaumcraft", "textures/gui/gui_research_back_over.png"));
 		
 		ThaumcraftApi.registerResearchLocation(new ResourceLocation(EngineeredGolems.MODID, "research/engineeredgolems"));
-    }
+		initGolems();
+	}
 	
 	public void postInit(FMLPostInitializationEvent event) {
 		


### PR DESCRIPTION
This fixes the same issue that is present in [Rustic Thaumaturgy](https://github.com/Voxel-Friend/Rustic-Thaumaturgy/pull/12), with the same disclaimer and explanation applying. I copied it here for convenience.

**EXTREMELY IMPORTANT NOTE**
While this does fix the issue of missing item requirements, it seems Azanor didn't have addons in mind when creating the golem system and made the saved golem materials dependent on registration order. This means that **MERGING THIS MAY CAUSE EXISTING GOLEMS TO CHANGE MATERIALS**. I guess it's up to you whether you want to open this can of worms (eldritch crabs maybe?) or not. 

You currently register the Ironwood golem material in `preInit`, which is before Thaumcraft registers its items (during the registry events that happen between `preInit` and `init`). This means that the items actually passed to the golem material are null. As a result, required items like the simple arcane mechanism are not actually required and replaced with air instead. Moving the registration to `init` is enough to solve the problem.